### PR TITLE
Remove included package in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "command not found handler for openSUSE"
 authors = ["Michal Vyskocil <michal.vyskocil@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "cnf_rs"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Poetry will check the installed packages from pyproject.toml and will error out when running `poetry install` if the package is not present. As we only have python files for testing, we do not need any packages.