### PR TITLE
remove configparser dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,16 +62,9 @@ name = "cnf-rs"
 version = "0.1.0"
 dependencies = [
  "bindgen",
- "configparser",
  "glob",
  "libc",
 ]
-
-[[package]]
-name = "configparser"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5458d9d1a587efaf5091602c59d299696a3877a439c8f6d461a2d3cce11df87a"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-configparser = "3.0.2"
 glob = "0.3.1"
 libc = "0.2.140"
 

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -1,0 +1,52 @@
+use std::fs::File;
+use std::io;
+use std::io::BufRead;
+use std::path::PathBuf;
+use std::result::Result;
+
+pub struct Repo {
+    pub enabled: bool,
+    pub name: String,
+}
+
+pub fn repo_enabled(path: &PathBuf) -> Result<Repo, String> {
+    let lines = read_lines(&path).map_err(stringify)?;
+    let mut name = String::from("N/A");
+
+    for line in lines {
+        if let Ok(ip) = line {
+            if ip.starts_with("[") && ip.ends_with("]") {
+                name = ip.replace(&['[', ']'][..], "");
+            }
+            if ip.starts_with("enabled") && ip.ends_with("1") {
+                return Ok(Repo {
+                    enabled: true,
+                    name,
+                });
+            }
+        }
+    }
+    Ok(Repo {
+        enabled: false,
+        name,
+    })
+}
+
+//https://doc.rust-lang.org/stable/rust-by-example/std_misc/file/read_lines.html
+
+// The output is wrapped in a Result to allow matching on errors
+// Returns an Iterator to the Reader of the lines of the file.
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<std::path::Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
+}
+
+fn stringify<T>(e: T) -> String
+where
+    T: std::fmt::Display,
+{
+    return format!("{}", e);
+}


### PR DESCRIPTION
New `ini` module provides exports `repo_enabled`, which has the minimum
functionality possible. It has 52 lines including rustfmt format,
imports and comments.

Finally enabled rustfmt fixer in neovim, reformat the code.
