### PR TITLE
A localization support

### DIFF
--- a/i18n/po/cs/cnf_rs.po
+++ b/i18n/po/cs/cnf_rs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cnf-rs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-08 10:49+0200\n"
+"POT-Creation-Date: 2023-06-16 08:48+0000\n"
 "PO-Revision-Date: 2018-10-07 21:47+0000\n"
 "Last-Translator: Aleš Kastner <alkas@volny.cz>\n"
 "Language-Team: Czech <https://l10n.opensuse.org/projects/scout/command-not-"
@@ -19,5 +19,40 @@ msgid ""
 "Absolute path to '{}' is '{}'. Please check your $PATH variable to see "
 "whether it contains the mentioned path."
 msgstr ""
-"Absolutní cesta k '{}' je '{}'. Prosím ověřte, zda "
-"proměnná $PATH obsahuje zmíněnou cestu."
+"Absolutní cesta k '{}' je '{}'. Prosím ověřte, zda proměnná $PATH obsahuje "
+"zmíněnou cestu."
+
+#: src/main.rs:43
+msgid ""
+"Absolute path to '{}' is '{}', so running it may require superuser "
+"privileges (eg. root)."
+msgstr ""
+"Absolutní cesta k programu '{}' je '{}', takže program je pravděpodobně "
+"určen pouze pro účet správce (například root)."
+
+#: src/main.rs:63
+msgid "command not found"
+msgstr "příkaz nenalezen"
+
+#: src/main.rs:69
+msgid "<selected_package>"
+msgstr "<vybraný_balíček>"
+
+#: src/main.rs:76
+msgid "The program '{}' can be found in the following package:"
+msgid_plural "The program '{}' can be found in following packages:"
+msgstr[0] "Program '{}' je možné najít v balíčku:"
+msgstr[1] "Program '{}' je možné najít v následujících balíčcích:"
+msgstr[2] "Program '{}' je možné najít v následujících balíčcích:"
+
+#: src/main.rs:86
+msgid "  * {} [ path: {}/{}, repository: {} ]"
+msgstr "  * {} [ cesta: {}/{}, repozitář: {} ]"
+
+#: src/main.rs:98
+msgid ""
+"Try installing with:\n"
+"   "
+msgstr ""
+"Pro instalaci spusťte:\n"
+"   "

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
 
     let sbin_path = &Path::new("/usr/sbin").join(Path::new(term));
     if Path::exists(sbin_path) {
-        println!("Absolute path to '{}' is '{}', so running it may require superuser privileges (eg. root).", term, sbin_path.display());
+        println!("{}", tr!("Absolute path to '{}' is '{}', so running it may require superuser privileges (eg. root).", term, sbin_path.display()));
         exit(0);
     }
 
@@ -60,35 +60,45 @@ fn search_solv(term: &str) -> Result<(), String> {
     let results = pool.search(&term);
 
     if results.len() == 0 {
-        return Err(format!(" {}: command not found", term));
+        return Err(format!(" {}: {}", term, tr!("command not found")));
     }
 
     let suggested_package = if results.len() == 1 {
         results[0].Package.clone()
     } else {
-        String::from("<selected_package>")
+        String::from(tr!("<selected_package>"))
     };
 
+    println!("");
     println!(
-        "
-The program '{}' can be found in following packages:",
-        &term
+        "{}",
+        tr!(
+            "The program '{}' can be found in the following package:"
+                | "The program '{}' can be found in following packages:" % results.len(),
+            &term
+        )
     );
 
     for r in results {
         println!(
-            "  * {} [ path: {}/{}, repository: zypp ({}) ]",
-            r.Package, r.Path, &term, r.Repo
+            "{}",
+            tr!(
+                "  * {} [ path: {}/{}, repository: {} ]",
+                r.Package,
+                r.Path,
+                &term,
+                r.Repo
+            )
         );
     }
 
-    println!(
-        "
-Try installing with:
-    sudo zypper install {}
-",
-        suggested_package
+    println!("");
+    print!(
+        "{}",
+        tr!("Try installing with:
+   ")
     );
+    println!(" sudo zypper install {}\n", suggested_package);
     Ok(())
 }
 


### PR DESCRIPTION
 * translate all happy path strings via `tr!`
 * convert `cs` translation from scout/command-not-found
 * a CI test for the `cs` case