### PR TITLE
Problem: lot of deprecated warnings in GHA logs

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -32,11 +32,11 @@ jobs:
         name: Build cnf-rs
         run: cargo build
 
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v2
 
       -
         name: Build openSUSE Tumbleweed image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Solution: use latest github docker action
